### PR TITLE
GoogleGifFetcher: scope WebView navigation to google.com

### DIFF
--- a/app/src/main/java/com/gifboard/GoogleGifFetcher.kt
+++ b/app/src/main/java/com/gifboard/GoogleGifFetcher.kt
@@ -147,6 +147,11 @@ class GoogleGifFetcher(private val webView: WebView) : GifProvider {
         }
 
         webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                val host = request?.url?.host ?: return true
+                return host != "www.google.com" && host != "google.com"
+            }
+
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)
                 view?.evaluateJavascript("""


### PR DESCRIPTION
Closes #40.

The headless WebView in `GoogleGifFetcher.search` accepted whatever URL Google handed it. The poll loop in `onPageFinished` only re-schedules when the finished URL contains `google.com/search`, so a redirect to a consent gate or any other host left the runnable unscheduled and the fetch hung until the per-call `timeoutMs`.

### Change

Add a `shouldOverrideUrlLoading` that blocks navigation when the request host is not `google.com` / `www.google.com`:

```kotlin
override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
    val host = request?.url?.host ?: return true
    return host != "www.google.com" && host != "google.com"
}
```

The initial `webView.loadUrl(url)` and any in-host pagination still proceed; only off-host navigation gets dropped, after which the existing `onReceivedError` / timeout path can resolve the coroutine.